### PR TITLE
Open files as binary

### DIFF
--- a/NaFlCore/helpers/mutator.py
+++ b/NaFlCore/helpers/mutator.py
@@ -59,7 +59,7 @@ class myFileGenerator():
 
         input_filename = os.path.join(self.mutations_dir, input_file)
 
-        with open(input_filename, 'r') as f:
+        with open(input_filename, 'rb') as f:
             original_contents = f.read()
 
         # Invoke Cthulhu! Yield a mutation!


### PR DESCRIPTION
I encountered some issues when fuzzing binary file formats caused by windows python converting bytes. This was fixed by opening the file in binary mode where python will not convert anything.

Just in case you're interested here's the fix.
